### PR TITLE
Fix naming function getPayment -> getPaymentInfo

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -162,7 +162,7 @@ YandexCheckout.prototype = {
    * @paramExample '6daac9fa-342d-4264-91c5-b5eafd1a0010'
    * @returns {Promise<Payment>}
    */
-  getPayment: function(paymentId, idempotenceKey) {
+  getPaymentInfo: function(paymentId, idempotenceKey) {
     var _self = this;
     return this._getPaymentInfo(paymentId, idempotenceKey).then(function(data) {
       return new Payment(_self, data);

--- a/samples/payment/get_payment.js
+++ b/samples/payment/get_payment.js
@@ -2,7 +2,7 @@ var YandexCheckout = require('../../lib/index')({ shopId: 'your_shop_id', secret
 var paymentId = 'your_payment_id';
 var idempotenceKey = 'your_idempotence_key'; // it is not required
 
-YandexCheckout.getPayment(paymentId, idempotenceKey)
+YandexCheckout.getPaymentInfo(paymentId, idempotenceKey)
   .then(function(result) {
     console.log({ payment: result });
   })

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -74,7 +74,7 @@ describe('Test all functionality', function () {
     });
 
     before(function () {
-      test = YandexCheckout.getPayment(responses.responseForCreate.id);
+      test = YandexCheckout.getPaymentInfo(responses.responseForCreate.id);
 
       return;
     });
@@ -282,7 +282,7 @@ describe('Test all functionality', function () {
     });
 
     before(function () {
-      test = YandexCheckout.getPayment(responses.responseForRefundCreateAndGet.id);
+      test = YandexCheckout.getPaymentInfo(responses.responseForRefundCreateAndGet.id);
 
       return;
     });
@@ -657,7 +657,7 @@ describe('Test all functionality', function () {
     });
 
     before(function () {
-      test = failYandexCheckout.getPayment(responses.responseForGetInfo.id);
+      test = failYandexCheckout.getPaymentInfo(responses.responseForGetInfo.id);
 
       return;
     });


### PR DESCRIPTION
As it seems to us, this is an obvious mistake in the overall stylization of naming. In addition, in the documentation (https://github.com/lodosstm/yandex-checkout-node/blob/master/README.ru.md) the function is called exactly getPaymentInfo.